### PR TITLE
lookup of incomplete keys

### DIFF
--- a/trie.c
+++ b/trie.c
@@ -47,11 +47,29 @@ void* trie_insert(struct trie* data, char* key, void* val)
         // try to find the correct child node
         struct trie* next_node = current_node->children[*key];
 
+        switch (current_node->type)
+        {
+            case trienode_twig:
+                // if this twig goes in the same direction
+                if (next_node)
+                {
+                    break;
+                }
+                // else it will promote to a branch
+            case trienode_leaf:
+                current_node->type++;
+        }
+
         // if next_node doesn't actually exist, create it
         if (!next_node) 
         {
             current_node->children[*key] = trie_create();
             next_node = current_node->children[*key];
+            if (trienode_twig == current_node->type)
+            {
+                // children[0] is never used; we'll hijack it as a fast-forward key
+                *current_node->children = next_node;
+            }
         }
 
         // set current node to the correct child node
@@ -75,6 +93,48 @@ void* trie_lookup(struct trie* data, char* key)
     if (!current_node)
     {
         return NULL;
+    }
+
+    return current_node->val;
+}
+
+// If there is only one key that maches the given `char* prefix`, returns its value. If there are several, returns the given `void* ambiguous`, if there are none, returns null.
+void* trie_lookup_prefix(struct trie* data, char* prefix, void* ambiguous)
+{
+    struct trie* current_node = trie_traverse(data, prefix);
+
+    if (!current_node)
+    {
+        return NULL;
+    }
+
+    // exact match
+    if(NULL!=current_node->val)
+    {
+        return current_node->val;
+    }
+
+    // prefix matched, but we still have to find the key itself
+    while(NULL==current_node->val)
+    {
+        switch(current_node->type)
+        {
+            case trienode_leaf:
+		// we can do nothing but return null
+                return current_node->val;
+            case trienode_twig:
+		// fast-forward to the next (only) child
+                current_node = *current_node->children;
+		continue;
+            case trienode_branch:
+		return ambiguous;
+        }
+    }
+
+    // we found a key with the requested prefix, but there are more
+    if(trienode_twig==current_node->type)
+    {
+        return ambiguous;
     }
 
     return current_node->val;
@@ -112,7 +172,7 @@ void trie_remove(struct trie* data, char* key)
 void trie_destroy(struct trie* data)
 {
     int a;
-    for (a = 0; a < 256; a++)
+    for (a = 1; a < 256; a++)
     {
         if (data->children[a])
         {

--- a/trie.h
+++ b/trie.h
@@ -5,6 +5,11 @@
 struct trie {
     void* val; // void* pointing at this node's data
     struct trie* children[256]; // constant size array of 256 child tries (one for each character)
+    enum {
+        trienode_leaf = 0, // has no children
+        trienode_twig, // has one child
+        trienode_branch, // has more than one child
+    } type; // hint about how many children there are
 };
 
 // creates a new trie and returns a pointer to that trie.
@@ -15,6 +20,9 @@ void* trie_insert(struct trie* data, char* key, void* val);
 
 // returns thing at key
 void* trie_lookup(struct trie* data, char* key);
+
+// returns thing at key matching prefix, if there are multiple matches, returns the ambiguous pointer
+void* trie_lookup_prefix(struct trie* data, char* prefix, void* ambiguous);
 
 // removes thing at key
 void trie_remove(struct trie* data, char* key);

--- a/trie_run.c
+++ b/trie_run.c
@@ -8,13 +8,15 @@
 int main(int argc, char* argv[])
 {
 
-	int *a, *b, *c;
+	int *a, *b, *c, *d;
 	a = malloc(sizeof(int));
 	*a = 1;
 	b = malloc(sizeof(int));
 	*b = 2;
 	c = malloc(sizeof(int));
 	*c = 3;
+	d = malloc(sizeof(int));
+	*d = 4;
 
 	struct trie* test_trie = trie_create();
 	printf("created new trie at %p\n", test_trie);
@@ -36,6 +38,12 @@ int main(int argc, char* argv[])
 
 	trie_value = trie_lookup(test_trie, "ccz");
 	printf("lookup got %d\n", *trie_value);
+
+	trie_value = trie_lookup_prefix(test_trie, "c", NULL);
+	printf("prefix lookup got %d\n", *trie_value);
+
+	trie_value = trie_lookup_prefix(test_trie, "a", d);
+	printf("ambiguous prefix lookup got %d\n", *trie_value);
 
 	trie_destroy(test_trie);
 	printf("freed trie\n");


### PR DESCRIPTION
Allows you to retrieve key "ccx" by asking for the prefix "c" or "cc" or "ccx".
